### PR TITLE
add input port model_pose to device

### DIFF
--- a/models/devices/gazebo/model.rb
+++ b/models/devices/gazebo/model.rb
@@ -13,7 +13,6 @@ module CommonModels
                 # Rename status_out and command_in to something that talks about
                 # joints
                 input_port 'joints_cmd', '/base/samples/Joints'
-                input_port 'model_pose', '/base/samples/RigidBodyState'
                 output_port 'joints_status', '/base/samples/Joints'
                 provides Services::JointsControlledSystem,
                     'command_in' => 'joints_cmd',

--- a/models/devices/gazebo/model.rb
+++ b/models/devices/gazebo/model.rb
@@ -13,6 +13,7 @@ module CommonModels
                 # Rename status_out and command_in to something that talks about
                 # joints
                 input_port 'joints_cmd', '/base/samples/Joints'
+                input_port 'model_pose', '/base/samples/RigidBodyState'
                 output_port 'joints_status', '/base/samples/Joints'
                 provides Services::JointsControlledSystem,
                     'command_in' => 'joints_cmd',

--- a/models/devices/gazebo/root_model.rb
+++ b/models/devices/gazebo/root_model.rb
@@ -7,6 +7,8 @@ module CommonModels
             device_type 'RootModel' do
                 provides Model
 
+                input_port 'model_pose', '/base/samples/RigidBodyState'
+                
                 provides Services::Pose
                 provides Services::Velocity,
                     'velocity_samples' => 'pose_samples'


### PR DESCRIPTION
This makes it possible to warp robots represented as devices, instead of requiring to use the modeltask directly.