### PR TITLE
Removing GraupnerMC20Task

### DIFF
--- a/models/orogen/controldev.rb
+++ b/models/orogen/controldev.rb
@@ -1,10 +1,6 @@
 require 'common_models/models/devices/input/joystick'
-require 'common_models/models/devices/input/graupner/mc20'
 
 class OroGen::Controldev::JoystickTask
     driver_for CommonModels::Devices::Input::Joystick, as: 'driver'
 end
 
-class OroGen::Controldev::GraupnerMC20Task
-    driver_for CommonModels::Devices::Input::Graupner::Mc20, as: 'driver'
-end


### PR DESCRIPTION
Currently the using_task_library 'controldev' throws an error because it doesn't recognize GraupnerMC20Task

```
OroGen[WARN]: subclasses is deprecated: in controldev: use task_context "Name", subclasses: "Parent" do .. end instead
gazebo[WARN]: ignored file models/orogen/controldev.rb
Roby[WARN]: undefined method `driver_for' for OroGen::Controldev::GraupnerMC20Task:Class (NoMethodError)
Roby[WARN]: = Backtrace
Roby[WARN]: = 

```
Signed-off-by: Alex Fernandes Neves <alexfneves@gmail.com>