### PR TITLE
add drivers/orogen/gps_base to the test dependencies

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -12,5 +12,6 @@
     <depend package="tools/syskit" />
     <test_depend package="minitest" />
     <test_depend package="flexmock" />
+    <test_depend package="drivers/orogen/gps_base" />
 </package>
 


### PR DESCRIPTION
It's "core enough" that it makes sense IMO