### PR TITLE
workaround bad interaction between the stub mechanism and flexmock

### DIFF
--- a/models/orogen/canbus.rb
+++ b/models/orogen/canbus.rb
@@ -23,7 +23,12 @@ class OroGen::Canbus::Task
     end
 
     stub do
+        def stub_configured_watches
+            @stub_configured_watches ||= []
+        end
+
         def watch(name, can_id, can_mask)
+            stub_configured_watches << [name, can_id, can_mask]
             create_input_port "w#{name}", '/canbus/Message'
             create_output_port name, '/canbus/Message'
         end

--- a/test/orogen/test_canbus.rb
+++ b/test/orogen/test_canbus.rb
@@ -20,9 +20,8 @@ module OroGen
                     dev_task = syskit_deploy(dev)
                     bus_task = dev_task.children.first
                     syskit_start_execution_agents(bus_task)
-                    flexmock(bus_task.orocos_task).should_receive(:watch).once.
-                        with('dev', 0x01, 0x11)
                     syskit_configure(bus_task)
+                    assert_equal [['dev', 0x1, 0x11]], bus_task.orocos_task.stub_configured_watches
                 end
             end
         end


### PR DESCRIPTION
`flexmock` as of yet does not handle `pass_thru` calls when the
next method in the stack has been inserted after the creation
of the partial mock.

This is what happens in this instance, where Syskit's stub mechanism
(which the canbus test relies on) inserts the stubbed `watch` method
just before calling `configure`. Since the mock was already setup,
calling pass_thru won't work and `watch` is never called. Since the
stubbed `watch` is what creates the ports, the configuration fails
(Syskit complains that dynamic ports that should have been created
have not been)

Change the test to instead rely on the stub storing the list of watched
IDs (which makes more sense from a testing perspective anyways).