### PR TITLE
convert orogen models to update_properties

### DIFF
--- a/models/orogen/camera_firewire.rb
+++ b/models/orogen/camera_firewire.rb
@@ -3,14 +3,20 @@
 require "common_models/models/blueprints/devices"
 require "common_models/models/blueprints/timestamping"
 
-class OroGen::CameraFirewire::CameraTask
+Syskit.extend_model OroGen.camera_firewire.CameraTask do
     driver_for Dev::Sensors::Cameras::Firewire, as: "driver"
     provides Base::TimestampInputSrv, as: "timestamps"
 
+    def update_properties
+        super if defined? super
+
+        if (p = robot_device.period)
+            properties.fps = (1.0 / p).round
+        end
+    end
+
     def configure
         super
-        if p = robot_device.period
-            orocos_task.fps = (1.0 / p).round
-        end
+        update_properties unless model.respond_to?(:use_update_properties?)
     end
 end

--- a/models/orogen/camera_usb.rb
+++ b/models/orogen/camera_usb.rb
@@ -5,10 +5,16 @@ require "common_models/models/blueprints/devices"
 class OroGen::CameraUsb::Task
     driver_for Dev::Sensors::Cameras::USB, as: "driver"
 
+    def update_properties
+        super if defined? super
+
+        if (p = robot_device.period)
+            properties.fps = (1.0 / p).round
+        end
+    end
+
     def configure
         super
-        if p = robot_device.period
-            orocos_task.fps = (1.0 / p).round
-        end
+        update_properties unless model.respond_to?(:use_update_properties?)
     end
 end

--- a/models/orogen/canbus.rb
+++ b/models/orogen/canbus.rb
@@ -2,7 +2,7 @@
 
 require "common_models/models/devices/bus/can"
 
-Syskit.extend_model OroGen.canbus.Task do
+Syskit.extend_model OroGen.canbus.Task do # rubocop:disable Metrics/BlockLength
     driver_for CommonModels::Devices::Bus::CAN, as: "driver"
 
     # This declares that all devices attached to this bus should use the 'in'
@@ -10,8 +10,13 @@ Syskit.extend_model OroGen.canbus.Task do
     # input port should be created
     provides CommonModels::Devices::Bus::CAN::BusInSrv, as: "to_bus"
 
+    def update_properties
+        super
+    end
+
     def configure
         super
+
         bus_name = self.driver_dev.name # self.canbus_name
         each_declared_attached_device do |dev|
             can_id, can_mask = dev.can_id

--- a/models/orogen/corridor_planner.rb
+++ b/models/orogen/corridor_planner.rb
@@ -13,10 +13,10 @@ class OroGen::CorridorPlanner::Task
     def configure
         super
         if Conf.traversability_map_file?
-            orocos_task.map_path = Conf.traversability_map_file
+            properties.map_path = Conf.traversability_map_file
         end
-        orocos_task.terrain_classes = Conf.traversability_classes_file
-        orocos_task.strong_edge_filter do |p|
+        properties.terrain_classes = Conf.traversability_classes_file
+        properties.strong_edge_filter do |p|
             p.env_path = Conf.environment_map_path
         end
     end

--- a/models/orogen/gps.rb
+++ b/models/orogen/gps.rb
@@ -4,12 +4,17 @@ require "common_models/models/devices/gps/mb500"
 require "common_models/models/devices/gps/generic"
 
 OroGen.extend_model OroGen.gps.BaseTask do
-    def configure
-        super
+    def update_properties
+        super if defined? super
 
         if Conf.utm_local_origin?
-            orocos_task.origin = Conf.utm_local_origin
+            properties.origin = Conf.utm_local_origin
         end
+    end
+
+    def configure
+        super
+        update_properties unless model.respond_to?(:use_update_properties?)
     end
 end
 

--- a/models/orogen/icp.rb
+++ b/models/orogen/icp.rb
@@ -5,6 +5,7 @@ require "common_models/models/blueprints/pose"
 class OroGen::Icp::Task
     find_output_port("pose_samples")
         .triggered_once_per_update
+
     worstcase_processing_time 1
 
     # Additional configuration for the transformer's automatic configuration
@@ -14,9 +15,15 @@ class OroGen::Icp::Task
         associate_frame_to_ports "laser", "scan_samples"
     end
 
+    def update_properties
+        super if defined? super
+
+        properties.environment_path = Conf.pointcloud_map_path
+    end
+
     def configure
         super
-        orogen_task.environment_path = Conf.pointcloud_map_path
+        update_properties unless model.respond_to?(:use_update_properties?)
     end
 end
 

--- a/models/orogen/mars.rb
+++ b/models/orogen/mars.rb
@@ -38,11 +38,6 @@ module OroGen::Mars
 
     class Task
         forward physics_error: :failed
-
-        def configure
-            # orocos_task.enable_gui = true
-            super
-        end
     end
 
     class AuvMotion

--- a/models/orogen/parport.rb
+++ b/models/orogen/parport.rb
@@ -16,8 +16,13 @@ end
 class OroGen::Parport::Task
     driver_for Dev::Bus::Parport, as: "driver"
 
+    def update_properties
+        super
+    end
+
     def configure
         super
+
         bus_name = self.parport_name
         each_attached_device do |dev|
             pin = dev.parport_pin


### PR DESCRIPTION
I did my best for those I don't use. The real issue here is
that (I believe) most of the models aren't actually used.

The change should be done in a way that is compatible with
older Syskit versions that do not have update_properties