### PR TITLE
Add Logger extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,6 @@ Naming/MethodParameterName:
   AllowedNames:
   - as
 
+Metrics/BlockLength:
+  Exclude:
+    - models/orogen/logger.rb

--- a/models/compositions/constant_generator.rb
+++ b/models/compositions/constant_generator.rb
@@ -35,6 +35,10 @@ module CommonModels
             # The writing thread
             attr_reader :write_thread
 
+            def update_properties
+                super
+            end
+
             # Sets the {#values} argument
             def values=(setpoint)
                 setpoint = setpoint.transform_keys(&:to_s)

--- a/models/orogen/logger.rb
+++ b/models/orogen/logger.rb
@@ -17,6 +17,14 @@ Syskit.extend_model Syskit::RockLogger do
     @logfile_indexes = {}
 
     provides Syskit::LoggerService
+    include Syskit::NetworkGeneration::LoggerConfigurationSupport
+
+    stub do
+        def createLoggingPort(port_name, port_type, _metadata) # rubocop:disable Naming/MethodName
+            create_input_port(port_name, port_type)
+            true
+        end
+    end
 
     # True if this logger is its deployment's default logger
     #

--- a/models/orogen/logger.rb
+++ b/models/orogen/logger.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Syskit
+    # Provide an alias for the RockLogger is set to the logger model in orogen/logger.rb
+    # as OroGen.logger is taken (can't access through OroGen.logger.LoggerTask)
+    RockLogger = OroGen.syskit_model_by_orogen_name("logger::Logger")
+end
+
+Syskit.extend_model Syskit::RockLogger do
+    class << self
+        attr_reader :logfile_indexes
+
+        def reset_log_indexes
+            @logfile_indexes = {}
+        end
+    end
+    @logfile_indexes = {}
+
+    provides Syskit::LoggerService
+
+    # True if this logger is its deployment's default logger
+    #
+    # In this case, it will set itself up using the deployment's logging
+    # configuration
+    attr_predicate :default_logger?, true
+
+    def update_properties
+        super
+
+        properties.overwrite_existing_files = false
+        properties.auto_timestamp_files = false
+    end
+
+    event :start do |context|
+        properties.file = default_logger_next_file_path if default_logger?
+
+        super(context)
+    end
+
+    def default_logger_file_name
+        orocos_name.sub(/_[L|l]ogger/, "")
+    end
+
+    def default_logger_next_index(log_file_name)
+        Syskit::RockLogger.logfile_indexes[log_file_name] =
+            Syskit::RockLogger.logfile_indexes.fetch(log_file_name, -1) + 1
+    end
+
+    def default_logger_log_dir
+        Syskit.conf.process_server_config_for(log_server_name).log_dir
+    end
+
+    # Sets up the default logger of this process
+    def default_logger_next_file_path
+        log_file_name = default_logger_file_name
+        index = default_logger_next_index(log_file_name)
+
+        log_file_path = "#{log_file_name}.#{index}.log"
+
+        log_dir = default_logger_log_dir
+        # NOTE: log_dir should be nil to mean "no log dir", not empty.
+        # This is a workaround to help migrating from Syskit code that sets it to empty
+        log_file_path = File.join(log_dir, log_file_path) if log_dir && !log_dir.empty?
+        log_file_path
+    end
+
+    def log_server_name
+        execution_agent.arguments[:on]
+    end
+
+    def rotate_log
+        return [] unless default_logger?
+
+        previous_file = properties.file
+        properties.file = default_logger_next_file_path
+        [previous_file]
+    end
+end

--- a/test/orogen/test_logger.rb
+++ b/test/orogen/test_logger.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+using_task_library "logger"
+
+module OroGen
+    # NOTE: RockLogger is set to the logger model in orogen/logger.rb as OroGen.logger
+    # is taken (can't access through OroGen.logger.LoggerTask)
+    describe Syskit::RockLogger do
+        def deploy_subject_syskit_model
+            use_deployment("rock_logger").first
+        end
+
+        it { is_configurable }
+
+        describe "handling of file on default loggers" do
+            before do
+                @deployment_m = Syskit::Deployment.new_submodel(name: "deployment") do
+                    add_default_logger
+                end
+            end
+
+            after do
+                Syskit::RockLogger.reset_log_indexes
+            end
+
+            it "initializes the file property, following the default logger pattern" do
+                deployment = syskit_stub_deployment("deployment", @deployment_m)
+                logger = deployment.task "deployment_Logger"
+                logger.default_logger = true
+                syskit_configure_and_start(logger)
+                assert_equal "deployment.0.log", logger.properties.file
+            end
+
+            it "increments the file index each time the same logger gets started" do
+                deployment = syskit_stub_deployment("deployment", @deployment_m)
+                logger = deployment.task "deployment_Logger"
+                logger.default_logger = true
+                syskit_configure_and_start(logger)
+                assert_equal "deployment.0.log", logger.properties.file
+
+                expect_execution { logger.stop! }.to { emit logger.stop_event }
+
+                logger = deployment.task "deployment_Logger"
+                logger.default_logger = true
+                syskit_configure_and_start(logger)
+                assert_equal "deployment.1.log", logger.properties.file
+            end
+
+            it "increments index in log file name when rotating the log" do
+                deployment = syskit_stub_deployment("deployment", @deployment_m)
+                logger = deployment.task "deployment_Logger"
+                logger.default_logger = true
+                syskit_configure_and_start(logger)
+
+                assert_equal "deployment.0.log", logger.properties.file
+                assert_equal ["deployment.0.log"], logger.rotate_log
+                assert_equal "deployment.1.log", logger.properties.file
+            end
+
+            it "does not rotate for loggers that are not a deployment's default logger" do
+                deployment = syskit_stub_deployment("deployment", @deployment_m)
+                logger = deployment.task "deployment_Logger"
+                logger.properties.file = "test.log"
+                syskit_configure_and_start(logger)
+
+                assert_equal "test.log", logger.properties.file
+                assert_equal [], logger.rotate_log
+                assert_equal "test.log", logger.properties.file
+            end
+
+            it "increments sequentially across rotations and restarts" do
+                deployment = syskit_stub_deployment("deployment", @deployment_m)
+                logger = deployment.task "deployment_Logger"
+                logger.default_logger = true
+                syskit_configure_and_start(logger)
+                logger.rotate_log
+                expect_execution { logger.stop! }.to { emit logger.stop_event }
+
+                logger = deployment.task "deployment_Logger"
+                logger.default_logger = true
+                syskit_configure_and_start(logger)
+                assert_equal "deployment.2.log", logger.properties.file
+            end
+        end
+    end
+end


### PR DESCRIPTION
 Depends on:
 - [ ] https://github.com/rock-core/tools-syskit/pull/291 
 - [x] https://github.com/rock-core/tools-logger/pull/13
 
The first due to the definition of `Syskit::LoggerService`, the second to allow setting `overwrite_existing_files`
 
 This is the continuation of https://github.com/rock-core/bundles-common_models/pull/34
  
 **- Overview:**
   - add a log rotation feature
   - move most logic specific to rock's logger to `orogen/logger.rb`
