### PR TITLE
feat: provide ThrusterController service

### DIFF
--- a/models/devices/gazebo/thruster.rb
+++ b/models/devices/gazebo/thruster.rb
@@ -8,6 +8,7 @@ module CommonModels
             device_type "Thruster" do
                 provides Entity
                 provides Services::Thruster
+                provides Services::ThrusterController
             end
         end
     end


### PR DESCRIPTION
We should be able to use the Thruster plugin as a thruster feedback provider.