### PR TITLE
fix: disable error reporting in the ConstantGenerator thread

### DIFF
--- a/models/compositions/constant_generator.rb
+++ b/models/compositions/constant_generator.rb
@@ -55,6 +55,9 @@ module CommonModels
                 @write_thread_exit = exit_event = Concurrent::Event.new
                 period = self.period
                 @write_thread = Thread.new do
+                    # Disable exception reporting. Uncaught exceptions are reported
+                    # through the write_thread_error event
+                    Thread.current.report_on_exception = false
                     until exit_event.set?
                         values.each do |port_name, value|
                             orocos_task.port(port_name).write(value)


### PR DESCRIPTION
Thread status is monitored by the task itself, and exceptions are reported through an event. No need to have Ruby pestering us about it as well.