### PR TITLE
feat: ray device provides depth map service

### DIFF
--- a/models/devices/gazebo/ray.rb
+++ b/models/devices/gazebo/ray.rb
@@ -2,7 +2,7 @@
 
 require "common_models/models/devices/gazebo/entity"
 require "common_models/models/services/laser_scan"
-require "seabots/models/services/depth_map"
+require "common_models/models/services/depth_map"
 
 module CommonModels
     module Devices
@@ -11,7 +11,7 @@ module CommonModels
             device_type "Ray" do
                 provides Entity
                 provides CommonModels::Services::LaserScan
-                provides Seabots::Services::DepthMap
+                provides CommonModels::Services::DepthMap
             end
         end
     end

--- a/models/devices/gazebo/ray.rb
+++ b/models/devices/gazebo/ray.rb
@@ -2,6 +2,7 @@
 
 require "common_models/models/devices/gazebo/entity"
 require "common_models/models/services/laser_scan"
+require "seabots/models/services/depth_map"
 
 module CommonModels
     module Devices
@@ -10,6 +11,7 @@ module CommonModels
             device_type "Ray" do
                 provides Entity
                 provides CommonModels::Services::LaserScan
+                provides Seabots::Services::DepthMap
             end
         end
     end

--- a/models/services.rb
+++ b/models/services.rb
@@ -31,6 +31,7 @@ require "common_models/models/services/raw_io"
 require "common_models/models/services/gazebo"
 
 require "common_models/models/services/laser_scan"
+require "common_models/models/services/depth_map"
 
 require "common_models/models/services/global_position"
 

--- a/models/services/depth_map.rb
+++ b/models/services/depth_map.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module CommonModels
+    module Services #:nodoc:
+        # A provider for depth map samples
+        data_service_type "DepthMap" do
+            output_port "depth_map", "/base/samples/DepthMap"
+        end
+    end
+end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/simulation-orogen-rock_gazebo/pull/30

A ray sensor declared in the sdf instance a ray device.
Now, the laser scan can output a depth map if the ray sensor is three-dimensional, so the ray device needs to provide a depth map service.