### PR TITLE
feat: directly allow using the Eigen::Vector3 and ::Quaternion classes on the v2 protocol

### DIFF
--- a/lib/common_models/roby_interface_marshallers.rb
+++ b/lib/common_models/roby_interface_marshallers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "eigen"
+require "roby/interface/v2/protocol"
+
+module CommonModels # :nodoc:
+    # Custom marshallers for the v2 Roby interface protocol
+    module RobyInterfaceMarshallers
+        def self.register_marshallers(registry)
+            registry.allow_classes(
+                Eigen::Vector3,
+                Eigen::Quaternion
+            )
+        end
+
+        def self.install
+            register_marshallers(Roby::Interface::V2::Protocol)
+        end
+
+        install
+    end
+end


### PR DESCRIPTION
This is meant to be used by listing `common_models/roby_interface_marshallers` under the `v2_protocol.extensions` config key in config/app.yml:

```
v2_protocol:
  extensions;
  - common_models/roby_interface_marshallers
```