### PR TITLE
fix: define values in the start event instead of initialize

### DIFF
--- a/models/compositions/dynamic_generator.rb
+++ b/models/compositions/dynamic_generator.rb
@@ -24,14 +24,15 @@ module CommonModels
         #   add_mission(mission)
         #   mission.values = { "out" => 42 }
         class DynamicGenerator < DataGenerator
-            def initialize(*, **)
-                @values = Concurrent::AtomicReference.new
-
+            def update_properties # rubocop:disable Lint/UselessMethodDefinition
                 super
             end
 
-            def update_properties # rubocop:disable Lint/UselessMethodDefinition
-                super
+            event :start do |context|
+                @values = Concurrent::AtomicReference.new
+                @values.set(arguments[:values])
+
+                super(context)
             end
 
             # Sets the {#values} argument
@@ -45,7 +46,11 @@ module CommonModels
                               "#{port_name} is not a known port of #{self}."
                     end
                 end
-                @values.set(setpoint)
+                if @values
+                    @values.set(setpoint)
+                else
+                    arguments[:values] = setpoint
+                end
             end
 
             def values


### PR DESCRIPTION
The model is copied a bunch of times during its deployment and startup phase, which led to `@values` being different from the one we set at the values= call. The fix is to define `@values` at startup and store the arguments if values is unset.