### PR TITLE
fix: pass a Syskit task model when defining deployment tasks

### DIFF
--- a/test/orogen/test_logger.rb
+++ b/test/orogen/test_logger.rb
@@ -19,7 +19,7 @@ module OroGen
         describe "handling of file on default loggers" do
             before do
                 @deployment_m = Syskit::Deployment.new_submodel(name: "deployment") do
-                    add_default_logger
+                    task "deployment_Logger", Syskit::RockLogger
                 end
             end
 


### PR DESCRIPTION
This fixes the warning (and the possibility of a heisenbug)