### PR TITLE
fix: dynamic generator #dup

### DIFF
--- a/models/compositions/dynamic_generator.rb
+++ b/models/compositions/dynamic_generator.rb
@@ -24,15 +24,20 @@ module CommonModels
         #   add_mission(mission)
         #   mission.values = { "out" => 42 }
         class DynamicGenerator < DataGenerator
+            def initialize(**keys)
+                @values = Concurrent::AtomicReference.new
+
+                super
+            end
+
             def update_properties # rubocop:disable Lint/UselessMethodDefinition
                 super
             end
 
-            event :start do |context|
-                @values = Concurrent::AtomicReference.new
-                @values.set(arguments[:values])
+            def initialize_copy(old)
+                super
 
-                super(context)
+                @values = Concurrent::AtomicReference.new(values)
             end
 
             # Sets the {#values} argument
@@ -46,11 +51,8 @@ module CommonModels
                               "#{port_name} is not a known port of #{self}."
                     end
                 end
-                if @values
-                    @values.set(setpoint)
-                else
-                    arguments[:values] = setpoint
-                end
+
+                @values.set(setpoint)
             end
 
             def values

--- a/test/compositions/test_dynamic_generator.rb
+++ b/test/compositions/test_dynamic_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "common_models/models/compositions/dynamic_generator"
+require "common_models/models/services/raw_output"
 
 module CommonModels
     module Compositions
@@ -61,6 +62,30 @@ module CommonModels
                 generator.values = { "out" => 42 }
                 sample = expect_execution.to { have_one_new_sample generator.out_port }
                 assert_in_delta 42, sample, 0.01
+            end
+
+            it "does not overwrite arguments" do
+                raw_packet_gen_m = DynamicGenerator.for("iodrivers_base/RawPacket")
+                # why does #new_submodel does not work with DynamicGenerator?
+                raw_packet_gen_m.class_eval do
+                    argument :initial_value
+
+                    def initial_value=(value)
+                        v = value.dup
+                        v.time = Time.now
+                        self.values = { "out" => v }
+                    end
+                end
+
+                raw = Types.iodrivers_base.RawPacket.new(
+                    time: Time.now
+                )
+                t0 = raw.time
+                task = syskit_stub_and_deploy(
+                    raw_packet_gen_m.with_arguments(initial_value: raw)
+                )
+
+                assert_equal t0, task.initial_value.time
             end
 
             describe "the task termination" do


### PR DESCRIPTION
do not use arguments {} to keep track of
@values data. It can break copy in a syskit
sense, such as changing the arguments while
going through network instanciation